### PR TITLE
Add heuristic auto layout and Shift+A shortcut

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
     <script src="js/element-creation.js"></script>
     <script src="js/comment-manager.js"></script>
     <script src="js/undo.js"></script>
+    <script src="js/auto-layout.js"></script>
     <script src="js/script-manager.js"></script>
     <script src="js/llm-prompt.js"></script>
     <script src="js/llm-manager.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -199,6 +199,21 @@ window.addEventListener('load', () => {
             e.preventDefault();
             groupSelectedElements();
         }
+        // Auto layout with Shift + A
+        if (e.key.toLowerCase() === 'a' && e.shiftKey && !e.metaKey && !e.ctrlKey) {
+            if (e.target.tagName === 'INPUT' ||
+                e.target.tagName === 'TEXTAREA' ||
+                e.target.contentEditable === 'true' ||
+                (window.codeEditor && window.codeEditor.isActive())) {
+                return; // Allow normal typing behavior in text fields
+            }
+            e.preventDefault();
+            const container = window.getSelectedElement ? window.getSelectedElement() : null;
+            if (container && window.applyAutoLayout) {
+                window.applyAutoLayout(container);
+            }
+        }
+
         
         // Undo with Cmd/Ctrl + Z
         if (e.key === 'z' && (e.metaKey || e.ctrlKey) && !e.shiftKey) {

--- a/js/auto-layout.js
+++ b/js/auto-layout.js
@@ -1,0 +1,96 @@
+// Auto-layout module: converts absolutely positioned children to flexbox layout
+
+(function() {
+    function applyAutoLayout(container) {
+        if (!container) return;
+
+        const children = Array.from(container.children).filter(el => el.nodeType === 1);
+        if (children.length === 0) return;
+
+        // Capture original HTML for undo
+        const oldHTML = container.outerHTML;
+
+        const containerRect = container.getBoundingClientRect();
+        const childData = children.map(el => {
+            const rect = el.getBoundingClientRect();
+            return {
+                element: el,
+                left: rect.left - containerRect.left,
+                top: rect.top - containerRect.top,
+                width: rect.width,
+                height: rect.height
+            };
+        });
+
+        const minLeft = Math.min(...childData.map(d => d.left));
+        const minTop = Math.min(...childData.map(d => d.top));
+        const maxLeft = Math.max(...childData.map(d => d.left));
+        const maxTop = Math.max(...childData.map(d => d.top));
+        const xRange = maxLeft - minLeft;
+        const yRange = maxTop - minTop;
+        const direction = xRange >= yRange ? 'row' : 'column';
+
+        // Sort children along the primary axis
+        childData.sort((a, b) => direction === 'row' ? a.left - b.left : a.top - b.top);
+
+        // Compute gaps between elements along primary axis
+        const gaps = [];
+        for (let i = 1; i < childData.length; i++) {
+            const prev = childData[i - 1];
+            const curr = childData[i];
+            const gap = direction === 'row'
+                ? curr.left - (prev.left + prev.width)
+                : curr.top - (prev.top + prev.height);
+            if (gap >= 0) gaps.push(gap);
+        }
+        let gapValue = 0;
+        if (gaps.length > 0) {
+            const sortedGaps = gaps.sort((a, b) => a - b);
+            gapValue = Math.round(sortedGaps[Math.floor(sortedGaps.length / 2)]);
+        }
+
+        // Apply flexbox layout to container
+        container.style.display = 'flex';
+        container.style.flexDirection = direction;
+        container.style.alignItems = 'flex-start';
+        container.style.gap = gapValue + 'px';
+        container.style.padding = '0';
+        container.style.paddingLeft = minLeft + 'px';
+        container.style.paddingTop = minTop + 'px';
+
+        // Update children styles and order
+        childData.forEach(data => {
+            const el = data.element;
+            el.style.position = 'relative';
+            el.style.left = '';
+            el.style.top = '';
+            el.classList.remove('free-floating');
+            el.style.margin = '0';
+            if (direction === 'row') {
+                el.style.marginTop = (data.top - minTop) + 'px';
+            } else {
+                el.style.marginLeft = (data.left - minLeft) + 'px';
+            }
+        });
+
+        // Reappend children in sorted order
+        childData.forEach(d => container.appendChild(d.element));
+
+        // Reinitialize selection/behavior for children
+        if (window.makeContainerElementsSelectable) {
+            window.makeContainerElementsSelectable(container);
+        }
+
+        const newHTML = container.outerHTML;
+        if (window.recordElementReplacement) {
+            window.recordElementReplacement(container.id, oldHTML, newHTML);
+        }
+
+        if (window.selectElement) {
+            window.selectElement(container);
+        }
+    }
+
+    window.applyAutoLayout = applyAutoLayout;
+})();
+


### PR DESCRIPTION
## Summary
- implement heuristic auto layout module that converts absolute children to flexbox
- wire Shift+A keyboard shortcut to trigger auto layout on selected container
- load new auto-layout script in index.html

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e21ce9550832db3a9ccf60a374944