### PR TITLE
Refine frame interactions and containment

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -26,7 +26,9 @@ function captureStartPositions(elements) {
 }
 
 function setupFrameDragging(frame, titleBar) {
-    frame.addEventListener('mousedown', (e) => {
+    if (!titleBar) return;
+
+    titleBar.addEventListener('mousedown', (e) => {
         // Check if in interactive mode
         if (window.canvasMode && window.canvasMode.isInteractiveMode()) {
             return;

--- a/js/marquee-selection.js
+++ b/js/marquee-selection.js
@@ -5,6 +5,7 @@ let marqueeElement = null;
 let isDragging = false;
 let dragThreshold = 5; // pixels
 let previewSelectedElements = new Set();
+let marqueeStartElement = null;
 
 // Create marquee element
 function createMarqueeElement() {
@@ -194,22 +195,25 @@ function initializeMarqueeSelection() {
     const canvas = document.getElementById('canvas');
     if (!canvas) return;
     
-    // Handle mousedown on canvas and body for selection clearing
+    // Handle mousedown on canvas, frame-content, and body for selection clearing
     document.addEventListener('mousedown', (e) => {
-        // Handle canvas clicks for marquee selection
-        if (e.target === canvas) {
+        const isCanvas = e.target === canvas;
+        const isFrameContent = e.target.classList && e.target.classList.contains('frame-content');
+
+        if (isCanvas || isFrameContent) {
             // Check if in interactive mode
             if (window.canvasMode && window.canvasMode.isInteractiveMode()) {
                 return;
             }
-            
+
             // Don't start marquee if panning or other operations
             if (window.isPanning) return;
             if (window.isInPlacementMode && window.isInPlacementMode()) return;
             if (window.isResizing && window.isResizing()) return;
-            
+
             // Store start position but don't start marquee yet
             marqueeStartPos = { x: e.clientX, y: e.clientY };
+            marqueeStartElement = isCanvas ? canvas : e.target;
             isDragging = false;
         }
         // Handle clicks on body for selection clearing
@@ -245,20 +249,21 @@ function initializeMarqueeSelection() {
             const addToSelection = e.shiftKey;
             endMarqueeSelection(e, addToSelection);
         } else if (marqueeStartPos.x !== 0 && marqueeStartPos.y !== 0 && !isDragging) {
-            // Simple click on canvas without drag - clear selections if not adding
+            // Simple click without drag - clear selections if not adding
             if (!e.shiftKey && window.clearSelection) {
                 window.clearSelection();
             }
-            
-            // Show CSS editor on canvas click (user requirement - blur focus from other elements)
-            if (window.codeEditor && window.codeEditor.showCSSEditor) {
+
+            // Show CSS editor only when clicking empty canvas
+            if (marqueeStartElement === canvas && window.codeEditor && window.codeEditor.showCSSEditor) {
                 window.codeEditor.showCSSEditor();
             }
         }
-        
+
         // Reset marquee state
         marqueeStartPos = { x: 0, y: 0 };
         isDragging = false;
+        marqueeStartElement = null;
     });
     
     // Cancel on escape

--- a/js/resize.js
+++ b/js/resize.js
@@ -329,6 +329,34 @@ function checkElementFrameContainment(elementFrame) {
             }
         }
     });
+
+    // Check free-floating siblings in parent container to absorb into this element-frame
+    const parent = elementFrame.parentElement || canvas;
+    const siblingElements = Array.from(parent.children).filter(el =>
+        el !== elementFrame && el.classList && el.classList.contains('free-floating')
+    );
+
+    siblingElements.forEach(element => {
+        const elementRect = element.getBoundingClientRect();
+        const elementCenter = {
+            x: elementRect.left + elementRect.width / 2,
+            y: elementRect.top + elementRect.height / 2
+        };
+
+        const newParent = findContainerAtPoint(elementCenter.x, elementCenter.y, element);
+
+        if (newParent === elementFrame) {
+            const zoom = window.canvasZoom ? window.canvasZoom.getCurrentZoom() : 1;
+            const newLeft = (elementRect.left - frameRect.left) / zoom;
+            const newTop = (elementRect.top - frameRect.top) / zoom;
+
+            elementFrame.appendChild(element);
+            element.style.left = newLeft + 'px';
+            element.style.top = newTop + 'px';
+
+            console.log(`📦 RESIZE: Element moved into new container (no script cleanup needed)`);
+        }
+    });
 }
 
 // Resize a text element to fit its content


### PR DESCRIPTION
## Summary
- Restrict frame movement to title bar drags so clicking inside content no longer drags the frame.
- Ensure element-frames absorb nearby free-floating elements and release those moved outside during resize.
- Enable marquee selection when dragging inside frame content and only show the CSS editor when clicking empty canvas.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e2970b91c832db8d81797b7579fbb