### PR TITLE
Fix chat history layout and restore scrolling

### DIFF
--- a/js/chat-history-tab.js
+++ b/js/chat-history-tab.js
@@ -111,7 +111,7 @@
         // Auto-resize textarea
         messageInput.addEventListener('input', () => {
             messageInput.style.height = 'auto';
-            messageInput.style.height = Math.min(messageInput.scrollHeight, 100) + 'px';
+            messageInput.style.height = Math.min(messageInput.scrollHeight, 200) + 'px';
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -915,6 +915,7 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     gap: 8px;
+    justify-content: flex-end;
 }
 
 /* Match scrollbar styling to other textareas */
@@ -1185,7 +1186,8 @@ input:checked + .mode-toggle-slider:before {
     padding: 12px;
     flex-shrink: 0;
     min-height: 100px; /* Fixed minimum height */
-    height: 100px; /* Fixed height */
+    display: flex;
+    flex-direction: column;
 }
 
 .message-controls {
@@ -1243,7 +1245,7 @@ input:checked + .mode-toggle-slider:before {
     outline: none;
     transition: border-color 0.2s;
     min-height: 36px;
-    max-height: 100px;
+    max-height: 200px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Anchor chat history messages to the bottom so they float upward as new messages arrive
- Allow chat input to expand while keeping a minimum height and restore message scroll bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e261700a8832d8162b5ea2f9b80c4