### PR TITLE
Fix chat history layout and restore scrolling

### DIFF
--- a/js/chat-history-tab.js
+++ b/js/chat-history-tab.js
@@ -111,7 +111,7 @@
         // Auto-resize textarea
         messageInput.addEventListener('input', () => {
             messageInput.style.height = 'auto';
-            messageInput.style.height = Math.min(messageInput.scrollHeight, 100) + 'px';
+            messageInput.style.height = Math.min(messageInput.scrollHeight, 200) + 'px';
         });
     }
 

--- a/styles.css
+++ b/styles.css
@@ -717,6 +717,7 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-height: 0;
 }
 
 /* Allow settings tab to scroll */
@@ -729,6 +730,7 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     background: #1a1a1a;
+    min-height: 0;
 }
 
 /* Code Editor Tab Specific Styles */
@@ -910,11 +912,13 @@ input:checked + .mode-toggle-slider:before {
 
 .enhancement-history-container {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 12px;
     display: flex;
     flex-direction: column;
     gap: 8px;
+    justify-content: flex-end;
 }
 
 /* Match scrollbar styling to other textareas */
@@ -1185,7 +1189,8 @@ input:checked + .mode-toggle-slider:before {
     padding: 12px;
     flex-shrink: 0;
     min-height: 100px; /* Fixed minimum height */
-    height: 100px; /* Fixed height */
+    display: flex;
+    flex-direction: column;
 }
 
 .message-controls {
@@ -1243,7 +1248,7 @@ input:checked + .mode-toggle-slider:before {
     outline: none;
     transition: border-color 0.2s;
     min-height: 36px;
-    max-height: 100px;
+    max-height: 200px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Keep right-pane content and chat tab containers at a fixed height to prevent layout overflow
- Add min-height rule to chat history list so overflow becomes scrollable and new messages stay above the input box
- Preserve message input at the bottom while letting the textarea grow upward as needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e261700a8832d8162b5ea2f9b80c4