### PR TITLE
Restore chat history scrolling and keep frame selection

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -95,9 +95,9 @@ window.addEventListener('load', () => {
         window.canvasMode.createToggleUI();
     }
     
-    // Show CSS editor on app load (user requirement)
-    if (window.codeEditor && window.codeEditor.showCSSEditor) {
-        window.codeEditor.showCSSEditor();
+    // Show Chat/History tab on app load
+    if (window.rightPaneManager) {
+        window.rightPaneManager.switchToTab('chat-history');
     }
     
     // Add keyboard shortcut to create new frames

--- a/js/chat-history-tab.js
+++ b/js/chat-history-tab.js
@@ -10,7 +10,8 @@
 
     // State management
     let tabContent = null;
-    let historyContainer = null;
+    let historyScroll = null;
+    let historyList = null;
     let enhancementHistory = []; // Array of enhancement request entries
     let currentSelectedFrame = null; // Track the currently selected frame
     let enhancementMode = 'editing'; // 'editing' or 'replacing'
@@ -42,10 +43,12 @@
                 <h3>Enhancement History</h3>
                 <p class="history-subtitle">AI frame enhancement requests (Ctrl+R)</p>
             </div>
-            <div class="enhancement-history-container" id="enhancement-history-list">
-                <div class="empty-history">
-                    <p>No enhancement requests yet.</p>
-                    <p><em>Select a frame and press Ctrl+R to get started!</em></p>
+            <div class="enhancement-history-scroll">
+                <div class="enhancement-history-container" id="enhancement-history-list">
+                    <div class="empty-history">
+                        <p>No enhancement requests yet.</p>
+                        <p><em>Select a frame and press Ctrl+R to get started!</em></p>
+                    </div>
                 </div>
             </div>
             <div class="message-input-section">
@@ -56,15 +59,15 @@
                     </div>
                 </div>
                 <div class="message-input-container">
-                    <textarea 
-                        id="custom-message-input" 
-                        class="message-textarea" 
+                    <textarea
+                        id="custom-message-input"
+                        class="message-textarea"
                         placeholder="Describe how to modify the existing code in the selected frame..."
                         rows="2"
                         data-selectable="false"></textarea>
-                    <button 
-                        id="send-message-btn" 
-                        class="send-message-button" 
+                    <button
+                        id="send-message-btn"
+                        class="send-message-button"
                         title="Send Custom Enhancement Request"
                         data-selectable="false">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -76,7 +79,8 @@
             </div>
         `;
 
-        historyContainer = container.querySelector('#enhancement-history-list');
+        historyScroll = container.querySelector('.enhancement-history-scroll');
+        historyList = container.querySelector('#enhancement-history-list');
         
         // Setup message input functionality
         setupMessageInput(container);
@@ -111,7 +115,7 @@
         // Auto-resize textarea
         messageInput.addEventListener('input', () => {
             messageInput.style.height = 'auto';
-            messageInput.style.height = Math.min(messageInput.scrollHeight, 100) + 'px';
+            messageInput.style.height = Math.min(messageInput.scrollHeight, 200) + 'px';
         });
     }
 
@@ -304,17 +308,17 @@
 
     // Render the full history (filtered by current frame)
     function renderHistory() {
-        if (!historyContainer) return;
+        if (!historyList || !historyScroll) return;
 
         // Update header to show current frame context
         updateHistoryHeader();
 
         // Clear existing content
-        historyContainer.innerHTML = '';
+        historyList.innerHTML = '';
 
         // Only show history if a frame is selected
         if (!currentSelectedFrame) {
-            historyContainer.innerHTML = `
+            historyList.innerHTML = `
                 <div class="empty-history">
                     <p>Select a frame to view its enhancement history.</p>
                     <p><em>Click on a frame, then press Ctrl+R to get started!</em></p>
@@ -329,7 +333,7 @@
         if (filteredHistory.length === 0) {
             const emptyMessage = `No enhancement requests for "${currentSelectedFrame.querySelector('.frame-title')?.textContent || 'this frame'}" yet.`;
                 
-            historyContainer.innerHTML = `
+            historyList.innerHTML = `
                 <div class="empty-history">
                     <p>${emptyMessage}</p>
                     <p><em>Press Ctrl+R to enhance this frame!</em></p>
@@ -344,11 +348,11 @@
         // Create cards for each entry
         sortedHistory.forEach(entry => {
             const card = createHistoryCard(entry);
-            historyContainer.appendChild(card);
+            historyList.appendChild(card);
         });
 
         // Scroll to bottom to show newest entries
-        historyContainer.scrollTop = historyContainer.scrollHeight;
+        historyScroll.scrollTop = historyScroll.scrollHeight;
     }
 
     // Update the history header to show current frame context

--- a/js/marquee-selection.js
+++ b/js/marquee-selection.js
@@ -214,8 +214,21 @@ function initializeMarqueeSelection() {
         }
         // Handle clicks on body for selection clearing
         else if (e.target === document.body) {
-            // Clear selections on empty space click
-            if (!e.shiftKey && window.clearSelection) {
+            const panel = document.getElementById('right-pane-panel');
+            const toggle = document.getElementById('right-pane-toggle');
+            const panelRect = panel ? panel.getBoundingClientRect() : null;
+            const toggleRect = toggle ? toggle.getBoundingClientRect() : null;
+
+            const inPanel = panelRect &&
+                e.clientX >= panelRect.left && e.clientX <= panelRect.right &&
+                e.clientY >= panelRect.top && e.clientY <= panelRect.bottom;
+
+            const inToggle = toggleRect &&
+                e.clientX >= toggleRect.left && e.clientX <= toggleRect.right &&
+                e.clientY >= toggleRect.top && e.clientY <= toggleRect.bottom;
+
+            // Clear selections on empty space click outside right pane controls
+            if (!inPanel && !inToggle && !e.shiftKey && window.clearSelection) {
                 window.clearSelection();
             }
         }

--- a/styles.css
+++ b/styles.css
@@ -717,6 +717,7 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    min-height: 0;
 }
 
 /* Allow settings tab to scroll */
@@ -729,6 +730,7 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     background: #1a1a1a;
+    min-height: 0;
 }
 
 /* Code Editor Tab Specific Styles */
@@ -908,31 +910,37 @@ input:checked + .mode-toggle-slider:before {
     margin: 0;
 }
 
-.enhancement-history-container {
+.enhancement-history-scroll {
     flex: 1;
+    min-height: 0;
     overflow-y: auto;
     padding: 12px;
     display: flex;
     flex-direction: column;
-    gap: 8px;
 }
 
-/* Match scrollbar styling to other textareas */
-.enhancement-history-container::-webkit-scrollbar {
+.enhancement-history-scroll::-webkit-scrollbar {
     width: 8px;
 }
 
-.enhancement-history-container::-webkit-scrollbar-track {
+.enhancement-history-scroll::-webkit-scrollbar-track {
     background: #1a1a1a;
 }
 
-.enhancement-history-container::-webkit-scrollbar-thumb {
+.enhancement-history-scroll::-webkit-scrollbar-thumb {
     background: #555;
     border-radius: 4px;
 }
 
-.enhancement-history-container::-webkit-scrollbar-thumb:hover {
+.enhancement-history-scroll::-webkit-scrollbar-thumb:hover {
     background: #666;
+}
+
+.enhancement-history-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: auto;
 }
 
 .empty-history {
@@ -1185,7 +1193,8 @@ input:checked + .mode-toggle-slider:before {
     padding: 12px;
     flex-shrink: 0;
     min-height: 100px; /* Fixed minimum height */
-    height: 100px; /* Fixed height */
+    display: flex;
+    flex-direction: column;
 }
 
 .message-controls {
@@ -1243,7 +1252,7 @@ input:checked + .mode-toggle-slider:before {
     outline: none;
     transition: border-color 0.2s;
     min-height: 36px;
-    max-height: 100px;
+    max-height: 200px;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- Wrap chat history in a dedicated scroll area so previous messages can be reviewed while new ones appear above the input
- Ignore right-pane clicks when clearing selection so frames stay selected when switching tabs
- Open the Chat/History tab by default when the app loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e261700a8832d8162b5ea2f9b80c4