### PR TITLE
fix: preserve frame selection and default chat tab

### DIFF
--- a/js/chat-history-tab.js
+++ b/js/chat-history-tab.js
@@ -33,6 +33,13 @@
 
         // Set up event listeners for enhancement events
         setupEnhancementEventListeners();
+
+        // Make Chat/History the default active tab on load
+        if (window.rightPaneManager &&
+            typeof window.rightPaneManager.getActiveTab === 'function' &&
+            !window.rightPaneManager.getActiveTab()) {
+            window.rightPaneManager.switchToTab('chat-history');
+        }
     }
 
     // Initialize tab content when first created

--- a/js/right-pane-manager.js
+++ b/js/right-pane-manager.js
@@ -22,6 +22,7 @@
     let contentContainer = null;
     let toggleButton = null;
     let closeButton = null;
+    let preservedSelection = [];
 
     // Initialize the right pane when the DOM is ready
     function init() {
@@ -65,6 +66,9 @@
 
     // Setup event listeners
     function setupEventListeners() {
+        // Preserve selection before tab click
+        tabContainer.addEventListener('mousedown', handleTabMouseDown);
+
         // Tab click handling
         tabContainer.addEventListener('click', handleTabClick);
         
@@ -84,7 +88,14 @@
         if (tabButton) {
             const tabId = tabButton.dataset.tab;
             userChosenTab = tabId; // Mark as user-chosen
-            switchToTab(tabId, { userInitiated: true });
+            switchToTab(tabId, { userInitiated: true, preservedSelection });
+            preservedSelection = [];
+        }
+    }
+
+    function handleTabMouseDown() {
+        if (window.getSelectedElements) {
+            preservedSelection = window.getSelectedElements();
         }
     }
 
@@ -173,6 +184,16 @@
 
         // Show panel if hidden
         showPanel();
+
+        // Restore selection if it was cleared by tab interaction
+        if (options.preservedSelection && options.preservedSelection.length &&
+            window.selectElement) {
+            options.preservedSelection.forEach(el => {
+                if (document.contains(el)) {
+                    window.selectElement(el, true);
+                }
+            });
+        }
     }
 
     function getActiveTab() {

--- a/styles.css
+++ b/styles.css
@@ -957,7 +957,6 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    justify-content: flex-end;
 }
 
 .enhancement-history-scroll::-webkit-scrollbar {
@@ -981,7 +980,6 @@ input:checked + .mode-toggle-slider:before {
     display: flex;
     flex-direction: column;
     gap: 8px;
-    margin-top: auto;
 }
 
 .empty-history {


### PR DESCRIPTION
## Summary
- allow scrolling within chat/history tab
- keep frame selections when switching right-pane tabs
- open chat/history by default at startup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4170bc6c832d9f9400a4dd984bd0