### PR TITLE
Allow frames to be dragged below viewport

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -501,12 +501,12 @@ function moveSingleElement(e) {
         const newLeft = canvasCoords.x - dragOffset.x;
         const newTop = canvasCoords.y - dragOffset.y;
         
-        // Keep frame within canvas bounds (in canvas coordinates)
+        // Keep frame within horizontal bounds and prevent going above the top
         const frameWidth = parseFloat(currentDragging.style.width) || currentDragging.offsetWidth;
-        const frameHeight = parseFloat(currentDragging.style.height) || currentDragging.offsetHeight;
-        
+
         currentDragging.style.left = Math.max(0, Math.min(newLeft, window.innerWidth / zoom - frameWidth)) + 'px';
-        currentDragging.style.top = Math.max(0, Math.min(newTop, window.innerHeight / zoom - frameHeight)) + 'px';
+        // Allow dragging below the viewport bottom
+        currentDragging.style.top = Math.max(0, newTop) + 'px';
     } else if (currentDragging.classList.contains('free-floating')) {
         // For free-floating elements, calculate relative to parent
         const parentRect = currentDragging.parentElement.getBoundingClientRect();
@@ -772,12 +772,12 @@ function moveFrameWithOffset(frame, offset, e) {
     const newLeft = canvasCoords.x - dragOffset.x + offset.x;
     const newTop = canvasCoords.y - dragOffset.y + offset.y;
     
-    // Keep frame within canvas bounds
+    // Keep frame within horizontal bounds and prevent going above the top
     const frameWidth = parseFloat(frame.style.width) || frame.offsetWidth;
-    const frameHeight = parseFloat(frame.style.height) || frame.offsetHeight;
-    
+
     frame.style.left = Math.max(0, Math.min(newLeft, window.innerWidth / zoom - frameWidth)) + 'px';
-    frame.style.top = Math.max(0, Math.min(newTop, window.innerHeight / zoom - frameHeight)) + 'px';
+    // Allow dragging below the viewport bottom
+    frame.style.top = Math.max(0, newTop) + 'px';
 }
 
 function moveElementWithOffset(element, offset, e) {


### PR DESCRIPTION
## Summary
- Allow top-level frames to extend below the viewport bottom during drag
- Maintain existing left and top constraints while permitting vertical overflow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4a4139f0832da881720c71464920