### PR TITLE
Prevent element-frame drag when interacting with nested elements

### DIFF
--- a/js/drag.js
+++ b/js/drag.js
@@ -154,8 +154,10 @@ function setupElementDragging(element) {
         // If this is an element-frame, only handle drag if clicking directly on the element-frame background
         // Don't handle drag for child elements - let them handle their own drag
         if (element.classList.contains('element-frame')) {
-            // If the click target is a child element with free-floating class, don't handle the drag
-            if (e.target !== element && e.target.classList.contains('free-floating')) {
+            // If the click occurred inside a nested free-floating element, let that element handle the drag.
+            // This accounts for clicks on text or other descendants within the free-floating element.
+            const freeFloatingAncestor = e.target.closest('.free-floating');
+            if (freeFloatingAncestor && freeFloatingAncestor !== element) {
                 return;
             }
         }


### PR DESCRIPTION
## Summary
- Avoid dragging an element-frame when mousedown occurs inside a nested free-floating element
- Detect ancestor `.free-floating` elements to ensure their own drag handler receives the event

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4b381250832db161c27c37da0343