### PR TITLE
Add left sidebar search widget with element and icon modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,9 @@
     <script src="js/chat-history-tab.js"></script>
     <script src="js/code-editor.js"></script>
     <script src="js/settings-context-tab.js"></script>
+    <script src="js/element-search.js"></script>
+    <script src="js/icon-search.js"></script>
+    <script src="js/left-sidebar.js"></script>
     <script src="js/app.js"></script>
 </body>
 </html>

--- a/js/element-creation.js
+++ b/js/element-creation.js
@@ -144,6 +144,30 @@ function startElementPlacement(elementType) {
     }
 }
 
+// Allow external modules to start placement with a pre-built element
+function startPlacementWithElement(element) {
+    if (placingElement) {
+        cancelElementPlacement();
+    }
+
+    placementMode = true;
+    placingElement = element;
+
+    placingElement.classList.add('placing-element');
+    document.body.appendChild(placingElement);
+
+    // Prevent any drag interactions on the placing element
+    placingElement.style.pointerEvents = 'none';
+
+    // Position at mouse location
+    document.addEventListener('mousemove', handlePlacementMouseMove);
+    document.addEventListener('mousedown', handlePlacementMouseDown);
+    document.addEventListener('mouseup', handlePlacementMouseUp);
+    document.addEventListener('keydown', handlePlacementKeydown);
+}
+
+window.startPlacementWithElement = startPlacementWithElement;
+
 function createFrameForPlacement() {
     frameCounter++;
     const frame = document.createElement('div');

--- a/js/element-search.js
+++ b/js/element-search.js
@@ -1,0 +1,48 @@
+(() => {
+    const elements = [
+        { name: 'Frame', type: 'frame' },
+        { name: 'Element Frame', type: 'element-frame' },
+        { name: 'Text', type: 'text' },
+        { name: 'Line', type: 'line' },
+        { name: 'Circle', type: 'circle' },
+        { name: 'Button', type: 'button' },
+        { name: 'Input', type: 'input' }
+    ];
+
+    let resultsContainer;
+
+    function updateResults(query) {
+        resultsContainer = document.getElementById('search-results');
+        if (!resultsContainer) return;
+        resultsContainer.classList.remove('icons');
+        resultsContainer.innerHTML = '';
+        const q = query.toLowerCase();
+        const matches = elements.filter(e => e.name.toLowerCase().includes(q));
+        matches.forEach((item, idx) => {
+            const div = document.createElement('div');
+            div.className = 'result';
+            div.textContent = item.name;
+            div.dataset.type = item.type;
+            div.setAttribute('data-selectable', 'false');
+            if (idx === 0) div.classList.add('selected');
+            div.addEventListener('click', () => startPlacement(item.type));
+            resultsContainer.appendChild(div);
+        });
+    }
+
+    function startPlacement(type) {
+        if (window.startElementPlacement) {
+            window.startElementPlacement(type);
+        }
+        if (window.leftSidebar) window.leftSidebar.collapse();
+    }
+
+    function handleEnter() {
+        const selected = document.querySelector('#search-results .result.selected');
+        if (selected) {
+            startPlacement(selected.dataset.type);
+        }
+    }
+
+    window.elementSearch = { updateResults, handleEnter };
+})();

--- a/js/icon-search.js
+++ b/js/icon-search.js
@@ -1,0 +1,56 @@
+(() => {
+    const icons = [
+        'academic-cap', 'adjustments-horizontal', 'archive-box', 'arrow-down-circle',
+        'arrow-right', 'calendar', 'camera', 'chart-bar', 'check-circle', 'cloud',
+        'code-bracket', 'heart', 'home', 'magnifying-glass', 'star', 'user'
+    ];
+
+    let resultsContainer;
+
+    function iconUrl(name) {
+        return `https://cdn.jsdelivr.net/npm/heroicons@2.0.18/24/outline/${name}.svg`;
+    }
+
+    function updateResults(query) {
+        resultsContainer = document.getElementById('search-results');
+        if (!resultsContainer) return;
+        resultsContainer.classList.add('icons');
+        resultsContainer.innerHTML = '';
+        const q = query.toLowerCase();
+        const matches = icons.filter(name => name.includes(q));
+        matches.forEach((name, idx) => {
+            const div = document.createElement('div');
+            div.className = 'result';
+            div.dataset.icon = name;
+            div.setAttribute('data-selectable', 'false');
+            const img = document.createElement('img');
+            img.src = iconUrl(name);
+            img.alt = name;
+            img.width = 24;
+            img.height = 24;
+            div.appendChild(img);
+            if (idx === 0) div.classList.add('selected');
+            div.addEventListener('click', () => placeIcon(name));
+            resultsContainer.appendChild(div);
+        });
+    }
+
+    function placeIcon(name) {
+        const img = document.createElement('img');
+        img.src = iconUrl(name);
+        img.className = 'icon-element free-floating';
+        img.width = 24;
+        img.height = 24;
+        window.startPlacementWithElement(img);
+        if (window.leftSidebar) window.leftSidebar.collapse();
+    }
+
+    function handleEnter() {
+        const selected = document.querySelector('#search-results .result.selected');
+        if (selected) {
+            placeIcon(selected.dataset.icon);
+        }
+    }
+
+    window.iconSearch = { updateResults, handleEnter };
+})();

--- a/js/left-sidebar.js
+++ b/js/left-sidebar.js
@@ -1,0 +1,96 @@
+(() => {
+    const sidebar = document.createElement('div');
+    sidebar.id = 'left-sidebar';
+    sidebar.setAttribute('data-selectable', 'false');
+
+    const elementsBtn = document.createElement('button');
+    elementsBtn.id = 'elements-search-btn';
+    elementsBtn.title = 'Search Elements';
+    elementsBtn.setAttribute('data-selectable', 'false');
+    elementsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>';
+
+    const iconsBtn = document.createElement('button');
+    iconsBtn.id = 'icon-search-btn';
+    iconsBtn.title = 'Search Icons';
+    iconsBtn.setAttribute('data-selectable', 'false');
+    iconsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>';
+
+    sidebar.appendChild(elementsBtn);
+    sidebar.appendChild(iconsBtn);
+
+    const searchContainer = document.createElement('div');
+    searchContainer.id = 'search-container';
+    const input = document.createElement('input');
+    input.id = 'search-input';
+    input.type = 'text';
+    input.placeholder = 'Search...';
+    const results = document.createElement('div');
+    results.id = 'search-results';
+    results.setAttribute('data-selectable', 'false');
+    searchContainer.appendChild(input);
+    searchContainer.appendChild(results);
+    sidebar.appendChild(searchContainer);
+
+    document.body.appendChild(sidebar);
+
+    let activeType = null;
+
+    function open(type) {
+        activeType = type;
+        sidebar.classList.add('expanded');
+        input.value = '';
+        results.innerHTML = '';
+        if (type === 'elements' && window.elementSearch) {
+            window.elementSearch.updateResults('');
+        } else if (type === 'icons' && window.iconSearch) {
+            window.iconSearch.updateResults('');
+        }
+        setTimeout(() => input.focus(), 0);
+    }
+
+    function collapse() {
+        sidebar.classList.remove('expanded');
+        activeType = null;
+        input.blur();
+    }
+
+    elementsBtn.addEventListener('click', () => open('elements'));
+    iconsBtn.addEventListener('click', () => open('icons'));
+
+    input.addEventListener('input', () => {
+        if (activeType === 'elements' && window.elementSearch) {
+            window.elementSearch.updateResults(input.value);
+        } else if (activeType === 'icons' && window.iconSearch) {
+            window.iconSearch.updateResults(input.value);
+        }
+    });
+
+    input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            if (activeType === 'elements' && window.elementSearch) {
+                window.elementSearch.handleEnter();
+            } else if (activeType === 'icons' && window.iconSearch) {
+                window.iconSearch.handleEnter();
+            }
+        } else if (e.key === 'Escape') {
+            collapse();
+        }
+    });
+
+    document.addEventListener('keydown', (e) => {
+        if (window.canvasMode && window.canvasMode.isInteractiveMode()) return;
+        if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.contentEditable === 'true' || (window.codeEditor && window.codeEditor.isActive())) return;
+        if (window.textEditing && window.textEditing.getCurrentlyEditingElement && window.textEditing.getCurrentlyEditingElement()) return;
+        if (window.isInPlacementMode && window.isInPlacementMode()) return;
+        if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+        if (e.key.toLowerCase() === 'e') {
+            e.preventDefault();
+            open('elements');
+        } else if (e.key.toLowerCase() === 'x') {
+            e.preventDefault();
+            open('icons');
+        }
+    });
+
+    window.leftSidebar = { open, collapse };
+})();

--- a/styles.css
+++ b/styles.css
@@ -1583,3 +1583,90 @@ input:checked + .mode-toggle-slider:before {
 .comment-bubble {
     z-index: 51; /* Above selection indicators but below drag/resize systems */
 }
+
+/* Left sidebar search widget */
+#left-sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: 40px;
+    background: #1a1a1a;
+    border-right: 1px solid #333;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 4px;
+    transition: width 0.2s;
+    z-index: 1000;
+}
+
+#left-sidebar.expanded {
+    width: 250px;
+}
+
+#left-sidebar button {
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    cursor: pointer;
+    padding: 4px;
+}
+
+#search-container {
+    display: none;
+    flex-direction: column;
+    flex: 1;
+    width: 100%;
+}
+
+#left-sidebar.expanded #search-container {
+    display: flex;
+}
+
+#search-input {
+    margin-bottom: 8px;
+    padding: 4px;
+    background: #0a0a0a;
+    color: #e0e0e0;
+    border: 1px solid #555;
+}
+
+#search-results {
+    flex: 1;
+    overflow-y: auto;
+}
+
+#search-results .result {
+    padding: 4px;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+#search-results .result.selected {
+    background: #333;
+}
+
+#search-results.icons {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, 32px);
+    gap: 8px;
+}
+
+#search-results.icons .result {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#search-results.icons .result.selected {
+    outline: 2px solid #4a90e2;
+}
+
+.icon-element {
+    width: 24px;
+    height: 24px;
+}


### PR DESCRIPTION
## Summary
- add left sidebar widget with buttons and search input for elements and icons
- implement element and icon search modules supporting keyboard shortcuts and placement
- support custom element placement via new helper in element-creation.js and style the sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4e1a669c832d8f8bb90966ec7c18