### PR TITLE
Enable drag reordering within flex containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Comprehensive CSS styling defining:
 
 #### `js/auto-layout.js`
 **Purpose**: Flexbox auto-layout conversion for absolutely positioned children
-- **Shift + A**: Apply auto-layout to selected container
+- **Shift + A**: Apply auto-layout to selected container (converts to flexbox and auto-resizes to fit children)
 - Detects dominant orientation by where most elements are positioned
 - Converts elements into a single horizontal row or vertical column with no outliers
 - Calculates padding from the space above and left of the upper-left element
-- Integrates with drag.js so dropped items join the container's flex flow
+- Integrates with drag.js so dropped items join the container's flex flow and elements can be reordered by dragging within the container
 
 #### `js/edge-detection.js`
 **Purpose**: Intelligent resize detection system with extended hit zones
@@ -467,6 +467,7 @@ Comprehensive CSS styling defining:
 - Elements automatically switch containers when dragged over new parents
 - Frame resizing triggers automatic container reassignment for contained elements
 - Zoom and pan operations maintain relative positioning
+- In flexbox containers created with **Shift + A**, dragging a child without Cmd/Ctrl reorders it within the flex flow
 
 ## Performance Optimizations
 

--- a/js/auto-layout.js
+++ b/js/auto-layout.js
@@ -62,6 +62,8 @@
         container.style.padding = '0';
         container.style.paddingLeft = minLeft + 'px';
         container.style.paddingTop = minTop + 'px';
+        container.style.width = 'fit-content';
+        container.style.height = 'fit-content';
 
         // Update children styles and order
         childData.forEach(data => {

--- a/js/drag.js
+++ b/js/drag.js
@@ -2,6 +2,10 @@ let currentDragging = null;
 let dragOffset = { x: 0, y: 0 };
 let isMultiDragging = false;
 let multiDragOffsets = new Map(); // Store relative positions of all selected elements
+let isFlexReordering = false;
+let flexContainer = null;
+let flexOldHTML = '';
+let flexDirection = 'row';
 
 // Alt/Option key duplication state
 let isAltPressed = false;
@@ -137,7 +141,26 @@ function setupElementDragging(element) {
         }
         
         if (e.metaKey || e.ctrlKey) return; // This is for extraction, not dragging
-        if (!element.classList.contains('free-floating')) return;
+        const parent = element.parentElement;
+        const parentStyle = parent ? window.getComputedStyle(parent) : null;
+
+        if (!element.classList.contains('free-floating')) {
+            if (parentStyle && parentStyle.display === 'flex') {
+                if (e.shiftKey && window.selectElement) {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    window.selectElement(element, true);
+                    return;
+                }
+                e.stopPropagation();
+                if (window.handleElementMouseDown && window.handleElementMouseDown(element, e)) {
+                    return;
+                }
+                e.stopImmediatePropagation();
+                startFlexReorderDrag(element, parent, parentStyle.flexDirection);
+            }
+            return;
+        }
         if (e.target.classList.contains('resize-handle')) return; // Don't drag if clicking resize handle
         if (window.isPanning) return; // Don't drag if panning
         
@@ -259,6 +282,36 @@ function setupElementDragging(element) {
         
         e.preventDefault();
     }, true); // Use capture phase to handle events before they bubble
+}
+
+function startFlexReorderDrag(element, container, direction) {
+    currentDragging = element;
+    isFlexReordering = true;
+    flexContainer = container;
+    flexDirection = direction.startsWith('column') ? 'column' : 'row';
+    flexOldHTML = container.outerHTML;
+    element.classList.add('dragging');
+    if (window.selectElement) {
+        window.selectElement(element);
+    }
+}
+
+function handleFlexReorderMove(e) {
+    if (!flexContainer) return;
+    const pointerX = e.clientX;
+    const pointerY = e.clientY;
+    const children = Array.from(flexContainer.children).filter(ch => ch !== currentDragging);
+    for (let child of children) {
+        const rect = child.getBoundingClientRect();
+        const before = flexDirection === 'row'
+            ? pointerX < rect.left + rect.width / 2
+            : pointerY < rect.top + rect.height / 2;
+        if (before) {
+            flexContainer.insertBefore(currentDragging, child);
+            return;
+        }
+    }
+    flexContainer.appendChild(currentDragging);
 }
 
 // Alt/Option key tracking for duplication
@@ -480,8 +533,10 @@ function abortDuplicateDrag() {
 // Global mouse move handler
 document.addEventListener('mousemove', (e) => {
     if (!currentDragging || window.isPanning) return;
-    
-    if (isMultiDragging) {
+
+    if (isFlexReordering) {
+        handleFlexReorderMove(e);
+    } else if (isMultiDragging) {
         moveMultiSelection(e);
     } else {
         moveSingleElement(e);
@@ -523,7 +578,21 @@ function moveSingleElement(e) {
 // Global mouse up handler
 document.addEventListener('mouseup', (e) => {
     if (!currentDragging) return;
-    
+    if (isFlexReordering) {
+        const newHTML = flexContainer ? flexContainer.outerHTML : '';
+        if (flexContainer && flexContainer.id && flexOldHTML !== newHTML && window.recordElementReplacement) {
+            window.recordElementReplacement(flexContainer.id, flexOldHTML, newHTML);
+        }
+        currentDragging.classList.remove('dragging');
+        currentDragging = null;
+        isFlexReordering = false;
+        flexContainer = null;
+        flexOldHTML = '';
+        flexDirection = 'row';
+        dragOffset = { x: 0, y: 0 };
+        return;
+    }
+
     // Always ensure we clean up the dragging state, regardless of any errors
     try {
         // Record movement for undo before handling container changes


### PR DESCRIPTION
## Summary
- Auto-layout now sets flex containers to `fit-content` for automatic sizing
- Dragging static elements inside a flex container reorders them instead of requiring extraction
- Document flexbox reordering behavior and updated Shift+A auto-layout

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/auto-layout.js`
- `node --check js/drag.js`


------
https://chatgpt.com/codex/tasks/task_e_689e4fd494ec832daf1757a2ac67152a