### PR TITLE
Create angled line element when using L key

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,8 @@
     background: #e0e0e0;
     border: none;
     border-radius: 0;
+    height: 2px;
+    transform-origin: 0 0;
 }
 
 /* Circle Element */

--- a/js/drag.js
+++ b/js/drag.js
@@ -185,7 +185,17 @@ function setupElementDragging(element) {
             // Edge detection handled the event (started resize) - don't drag
             return;
         }
-        
+
+        // Special handling for line elements: dragging adjusts angle and length
+        if (element.classList.contains('line-element')) {
+            e.stopImmediatePropagation();
+            e.preventDefault();
+            if (window.startResize) {
+                window.startResize(e, element, 'se');
+            }
+            return;
+        }
+
         e.stopImmediatePropagation(); // Prevent any other handlers from firing
         
         // Handle alt+drag for duplication

--- a/js/element-creation.js
+++ b/js/element-creation.js
@@ -27,6 +27,7 @@ function createLineElement() {
     element.className = 'line-element free-floating';
     element.style.width = '100px';
     element.style.height = '2px';
+    element.style.transformOrigin = '0 0';
     element.id = `line-${elementCounter}`;
     return element;
 }
@@ -203,16 +204,21 @@ function handlePlacementMouseUp(e) {
             // Simple click - just place the element
             placeElement(e.clientX, e.clientY);
         } else {
-            // Was dragging - element is already placed and being resized
-            // Clean up resize state
-            if (resizeTarget) {
-                resizeTarget.classList.remove('resizing');
-                resizing = false;
-                resizeTarget = null;
-                resizeHandle = null;
+            if (placingElement.classList.contains('line-element')) {
+                // Finalize line placement at start point
+                placeElement(placementStartPos.x, placementStartPos.y);
+            } else {
+                // Was dragging - element is already placed and being resized
+                // Clean up resize state
+                if (resizeTarget) {
+                    resizeTarget.classList.remove('resizing');
+                    resizing = false;
+                    resizeTarget = null;
+                    resizeHandle = null;
+                }
+
+                console.log(`Element placed and resized`);
             }
-            
-            console.log(`Element placed and resized`);
         }
     } catch (error) {
         console.error('Error during placement mouse-up:', error);
@@ -233,26 +239,35 @@ function handlePlacementMouseUp(e) {
 
 function handlePlacementMouseMove(e) {
     if (!placingElement) return;
-    
+
     if (placementStartPos.x !== 0 && !isPlacementDragging) {
-        // Check if we've moved enough to start drag-resize
+        // Check if we've moved enough to start drag-placement
         const deltaX = e.clientX - placementStartPos.x;
         const deltaY = e.clientY - placementStartPos.y;
         const distance = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-        
-        if (distance > 5) { // Start drag-resize after 5px movement
+
+        if (distance > 5) { // Start drag after 5px movement
             isPlacementDragging = true;
-            
+
+            if (placingElement.classList.contains('line-element')) {
+                // Anchor line at start point
+                placingElement.style.left = placementStartPos.x + 'px';
+                placingElement.style.top = placementStartPos.y + 'px';
+                placingElement.style.width = '0px';
+                placingElement.style.height = '2px';
+                return;
+            }
+
             // Place the element at the START position (where mouse was first pressed)
             const placedElement = placeElement(placementStartPos.x, placementStartPos.y);
-            
+
             if (placedElement) {
                 // Start with minimal size - let the resize system handle all sizing
                 // This ensures the element fits exactly between drop point and mouse
                 const minSize = 1;
                 placedElement.style.width = minSize + 'px';
                 placedElement.style.height = minSize + 'px';
-                
+
                 // Set up resize state to track from the placement start position
                 // The resize system will size the element to exactly where the mouse is
                 resizing = true;
@@ -260,20 +275,31 @@ function handlePlacementMouseMove(e) {
                 resizeHandle = 'se'; // Southeast corner resize
                 resizeStartPos = { x: placementStartPos.x, y: placementStartPos.y }; // Anchor at drop point
                 resizeStartSize = { width: minSize, height: minSize }; // Minimal starting size
-                resizeStartOffset = { 
-                    left: parseFloat(placedElement.style.left) || 0, 
-                    top: parseFloat(placedElement.style.top) || 0 
+                resizeStartOffset = {
+                    left: parseFloat(placedElement.style.left) || 0,
+                    top: parseFloat(placedElement.style.top) || 0
                 };
                 isDragToResize = true; // Enable direct sizing mode
-                
+
                 placedElement.classList.add('resizing');
                 bringToFront(placedElement);
-                
+
                 return; // Don't update position since we're now resizing
             }
         }
     }
-    
+
+    if (isPlacementDragging && placingElement && placingElement.classList.contains('line-element')) {
+        // Update line length and angle based on mouse position
+        const deltaX = e.clientX - placementStartPos.x;
+        const deltaY = e.clientY - placementStartPos.y;
+        const length = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+        const angle = Math.atan2(deltaY, deltaX) * 180 / Math.PI;
+        placingElement.style.width = length + 'px';
+        placingElement.style.transform = `rotate(${angle}deg)`;
+        return;
+    }
+
     if (!isPlacementDragging) {
         // Normal mouse following
         placingElement.style.left = e.clientX + 'px';

--- a/styles.css
+++ b/styles.css
@@ -428,6 +428,8 @@ body.shift-selecting {
     background: #e0e0e0;
     border: none;
     border-radius: 0;
+    height: 2px;
+    transform-origin: 0 0;
 }
 
 .circle-element {


### PR DESCRIPTION
## Summary
- Anchor line elements at drag start and rotate to match drag angle
- Add transform-origin styling for line elements
- Let existing lines be re-angled and resized by dragging or using resize handles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4ea95e50832d96494b4099c8b43d