### PR TITLE
Restrict canvas editing scope and fix settings prompt textarea sizing

### DIFF
--- a/js/text-editing.js
+++ b/js/text-editing.js
@@ -110,6 +110,11 @@
         if (target.closest('#mode-toggle-container')) {
             return null;
         }
+
+        // Only allow editing for elements within the canvas
+        if (!target.closest('#canvas')) {
+            return null;
+        }
         
         // Check for input wrapper for placeholder editing
         const inputWrapper = target.closest('.input-wrapper');

--- a/styles.css
+++ b/styles.css
@@ -1194,6 +1194,10 @@ input:checked + .mode-toggle-slider:before {
     overflow-y: auto;
     outline: none;
     transition: border-color 0.2s;
+    width: 100%;
+    box-sizing: border-box;
+    flex: 1 0 auto;
+    display: block;
 }
 
 .prompt-textarea:focus {


### PR DESCRIPTION
## Summary
- Limit inline text editing to canvas elements so double-clicking in the right pane no longer affects its tabs
- Ensure Settings/Context tab prompt textareas expand to full width for consistent styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e5e64ae34832db61ab54a1c0ed1d0