### PR TITLE
Fix Shift+A auto-layout retaining container size

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Comprehensive CSS styling defining:
 
 #### `js/auto-layout.js`
 **Purpose**: Flexbox auto-layout conversion for absolutely positioned children
-- **Shift + A**: Apply auto-layout to selected container (converts to flexbox and auto-resizes to fit children)
+- **Shift + A**: Apply auto-layout to selected container (converts to flexbox while preserving the container's original width and height)
 - Detects dominant orientation by where most elements are positioned
 - Converts elements into a single horizontal row or vertical column with no outliers
 - Calculates padding from the space above and left of the upper-left element

--- a/js/auto-layout.js
+++ b/js/auto-layout.js
@@ -62,8 +62,8 @@
         container.style.padding = '0';
         container.style.paddingLeft = minLeft + 'px';
         container.style.paddingTop = minTop + 'px';
-        container.style.width = 'fit-content';
-        container.style.height = 'fit-content';
+        container.style.width = containerRect.width + 'px';
+        container.style.height = containerRect.height + 'px';
 
         // Update children styles and order
         childData.forEach(data => {


### PR DESCRIPTION
## Summary
- Ensure auto-layout retains original container width and height instead of collapsing
- Document that Shift+A preserves container dimensions

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e66d97d88832dabc985775c4726f6