### PR TITLE
Enhance left sidebar labels and icon search

### DIFF
--- a/js/icon-search.js
+++ b/js/icon-search.js
@@ -1,8 +1,13 @@
 (() => {
     const icons = [
-        'academic-cap', 'adjustments-horizontal', 'archive-box', 'arrow-down-circle',
-        'arrow-right', 'calendar', 'camera', 'chart-bar', 'check-circle', 'cloud',
-        'code-bracket', 'heart', 'home', 'magnifying-glass', 'star', 'user'
+        'academic-cap', 'adjustments-horizontal', 'archive-box',
+        'arrow-down', 'arrow-down-circle', 'arrow-left', 'arrow-right', 'arrow-up',
+        'arrow-down-left', 'arrow-down-right', 'arrow-up-left', 'arrow-up-right',
+        'bars-3', 'calendar', 'camera', 'chart-bar', 'check-circle',
+        'chevron-down', 'chevron-left', 'chevron-right', 'chevron-up',
+        'cloud', 'cloud-arrow-up', 'code-bracket', 'cog-6-tooth',
+        'heart', 'home', 'magnifying-glass', 'star', 'user',
+        'x-mark', 'arrow-up-tray'
     ];
 
     let resultsContainer;

--- a/js/left-sidebar.js
+++ b/js/left-sidebar.js
@@ -7,13 +7,13 @@
     elementsBtn.id = 'elements-search-btn';
     elementsBtn.title = 'Search Elements';
     elementsBtn.setAttribute('data-selectable', 'false');
-    elementsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>';
+    elementsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg><span class="label">Elements</span>';
 
     const iconsBtn = document.createElement('button');
     iconsBtn.id = 'icon-search-btn';
     iconsBtn.title = 'Search Icons';
     iconsBtn.setAttribute('data-selectable', 'false');
-    iconsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>';
+    iconsBtn.innerHTML = '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg><span class="label">Icons</span>';
 
     sidebar.appendChild(elementsBtn);
     sidebar.appendChild(iconsBtn);

--- a/styles.css
+++ b/styles.css
@@ -1615,6 +1615,7 @@ input:checked + .mode-toggle-slider:before {
 #left-sidebar.expanded {
     width: 250px;
     max-height: 70vh;
+    align-items: flex-start;
 }
 
 #left-sidebar button {
@@ -1623,6 +1624,25 @@ input:checked + .mode-toggle-slider:before {
     color: #fff;
     cursor: pointer;
     padding: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 32px;
+}
+
+#left-sidebar button .label {
+    display: none;
+    font-size: 14px;
+}
+
+#left-sidebar.expanded button {
+    width: 100%;
+    justify-content: flex-start;
+}
+
+#left-sidebar.expanded button .label {
+    display: inline;
 }
 
 #search-container {


### PR DESCRIPTION
## Summary
- Show Elements and Icons labels beside sidebar buttons when expanded
- Expand icon search to include arrows, chevrons, close, settings, menu, upload and more

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5153d124832d80b3bf6ca66d88d8